### PR TITLE
Upgrade to python 3.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
-FROM python
+FROM python:3.11
 
 WORKDIR /code
 
-COPY python/env/manualclassify .
 COPY python/env/requirements.txt .
 
 RUN pip install -r requirements.txt
+
+COPY python/env/manualclassify .

--- a/python/env/requirements.txt
+++ b/python/env/requirements.txt
@@ -1,5 +1,5 @@
-django==3
+django>=3.2,<4
 requests
-psycopg2>=2.8,<2.9
+psycopg2>=2.9.5,<2.10
 iso8601
 gunicorn


### PR DESCRIPTION
Pin Dockerfile base image to 3.11, and upgrade
dependencies in requirements.txt accordingly.
psycopg2 2.9.5 and django 3.2+ are needed
for compatibility.

Also install dependencies before adding code in the Dockerfile so that dependencies aren't reinstalled after every code change.