### PR TITLE
Parameterize user registration email

### DIFF
--- a/django_conf/local_settings.py.template
+++ b/django_conf/local_settings.py.template
@@ -17,3 +17,4 @@ INACTIVE_USER_LIMIT = 25
 
 CACHE_DIR = '/annotate_cache'
 
+USER_REGISTRATION_EMAIL = 'epeacock@whoi.edu'

--- a/python/env/manualclassify/classify/views.py
+++ b/python/env/manualclassify/classify/views.py
@@ -65,7 +65,10 @@ class LoginPageView(TemplateView):
                     login(request, user)
                     return redirectResponse("/")
                 else:
-                    return alertResponse("This account needs to be enabled by an administrator, please email epeacock@whoi.edu.")
+                    return alertResponse(
+                        "This account needs to be enabled by an administrator, "
+                        f"please email {settings.USER_REGISTRATION_EMAIL}."
+                    )
             else:
                 return alertResponse("Invalid credentials.")
 
@@ -146,7 +149,9 @@ class RegisterPageView(TemplateView):
         user.is_active = False
         user.is_staff = True
         user.save()
-        return alertResponse("Success! Your account has been registered, but needs to be enabled. Please email epeacock@whoi.edu.", False)
+        return alertResponse((
+                "Success! Your account has been registered, but needs to be enabled. "
+                f"Please email {settings.USER_REGISTRATION_EMAIL}."), False)
 
 class LogoutPageView(TemplateView):
     def get(self, request, **kwargs):


### PR DESCRIPTION
Make the email users should contact for account approval configurable. The other option would be to use the email of the superuser account, but this is more flexible.